### PR TITLE
Add missing Content-Length header

### DIFF
--- a/Dota2 AI Addon/game/dota_addons/dota2ai/scripts/vscripts/addon_game_mode.lua
+++ b/Dota2 AI Addon/game/dota_addons/dota2ai/scripts/vscripts/addon_game_mode.lua
@@ -2,6 +2,7 @@
 	request = CreateHTTPRequest( "POST", Dota2AI.baseURL .. "/select")
 	request:SetHTTPRequestHeaderValue("Accept", "application/json")
 	request:SetHTTPRequestHeaderValue("X-Jersey-Tracing-Threshold", "VERBOSE" )
+	request:SetHTTPRequestHeaderValue("Content-Length", "0")
 	request:Send( function( result ) 
     
 	if result["StatusCode"] == 200 then       

--- a/Dota2 AI Addon/game/dota_addons/dota2ai/scripts/vscripts/events.lua
+++ b/Dota2 AI Addon/game/dota_addons/dota2ai/scripts/vscripts/events.lua
@@ -84,6 +84,7 @@ end
   function Dota2AI:BotLevelUp(heroEntity) 
 	  request = CreateHTTPRequest( "POST", Dota2AI.baseURL .. "/levelup")
 	  request:SetHTTPRequestHeaderValue("Accept", "application/json")
+	  request:SetHTTPRequestHeaderValue("Content-Length", "0")
 	  request:Send( function( result ) 
 		  if result["StatusCode"] == 200 then       
 			self:ParseHeroLevelUp(heroEntity, result['Body']) 


### PR DESCRIPTION
POST calls should have Content-Length header set, for server to know the length of the message.
